### PR TITLE
Feature to skip header in csv files without interfering with existing behavior, minor changes to fra script

### DIFF
--- a/impedancefitter/fitter.py
+++ b/impedancefitter/fitter.py
@@ -209,6 +209,9 @@ class Fitter(object):
         self.savemodelresult = True
         self.report = False
 
+        # for csv files
+        self.skiprows_csv = 0  # header rows inside the *.csv files
+
         # for txt files
         self.trace_b = None
         self.skiprows_txt = 1  # header rows inside the *.txt files
@@ -243,6 +246,8 @@ class Fitter(object):
             self.trace_b = kwargs['trace_b']
         if 'skiprows_txt' in kwargs:
             self.skiprows_txt = int(kwargs['skiprows_txt'])
+        if 'skiprows_csv' in kwargs:
+            self.skiprows_csv = int(kwargs['skiprows_csv'])
         if 'skiprows_trace' in kwargs:
             self.skiprows_trace = int(kwargs['skiprows_trace'])
         if 'show' in kwargs:
@@ -530,7 +535,8 @@ class Fitter(object):
             omega, zarray = readin_Data_from_collection(filepath, 'CSV',
                                                         delimiter=self.delimiter,
                                                         minimumFrequency=self.minimumFrequency,
-                                                        maximumFrequency=self.maximumFrequency)
+                                                        maximumFrequency=self.maximumFrequency,
+                                                        header=self.skiprows_csv)
         elif self.inputformat == 'CSV_E4980AL' and filename.endswith(".csv"):
             omega, zarray = readin_Data_from_csv_E4980AL(filepath,
                                                          minimumFrequency=self.minimumFrequency,

--- a/impedancefitter/fitter.py
+++ b/impedancefitter/fitter.py
@@ -151,7 +151,7 @@ class Fitter(object):
         self.z_dict = {}
         # read in all data and store it
         if self.fileList is None:
-            self.fileList = os.listdir(self.directory)
+            self.fileList = sorted(os.listdir(self.directory))
         read_data_sets = 0
         for filename in self.fileList:
             if self.data_sets:

--- a/impedancefitter/fra.py
+++ b/impedancefitter/fra.py
@@ -263,3 +263,15 @@ def bode_csv_to_impedance(filename, devicename, R_device=1e6):
     """
     frequency, attenuation, phase = read_bode_csv(filename, devicename)
     return bode_to_impedance(frequency, attenuation, phase, R_device=R_device)
+
+
+def neisys_to_impedance(filename, header=2):
+    data = pandas.read_csv(filename, header=header)
+    frequencies = np.array(data['  Freq. [Hz]  '])
+    Z_dut = np.array(data['  |Z| [ohm]  '])
+    phase = np.array(data['  Phi [deg]'])
+
+    omega = 2. * np.pi * frequencies
+    Z = mag_phase_to_complex(Z_dut, phase)
+
+    return omega, Z

--- a/impedancefitter/fra.py
+++ b/impedancefitter/fra.py
@@ -275,3 +275,4 @@ def neisys_to_impedance(filename, header=2):
     Z = mag_phase_to_complex(Z_dut, phase)
 
     return omega, Z
+

--- a/impedancefitter/fra.py
+++ b/impedancefitter/fra.py
@@ -135,8 +135,17 @@ def bode_to_impedance(frequency, attenuation, phase, R_device=1e6):
 
     Notes
     -----
+    Given the expression for the magnitude of a voltage in dB is
+    .. math::
+        M_{db} = 20 log{\frac{V_1}{V_{ref}}}
 
-    TBD: explain conversion formula
+    we calculte the voltage ratio from the attenuation in dB as
+    .. math::
+        ratio_{votlage} = 10^{M_{dB} / 20}
+
+    Then, the voltage divider rule results in the magnitude of the impedance as
+    .. math::
+        Z_{dut} = ratio * R_{shunt} - R_{shunt}
     """
     vratio = 10**(attenuation / 20)
     Z_dut = vratio * R_device - R_device

--- a/impedancefitter/fra.py
+++ b/impedancefitter/fra.py
@@ -64,6 +64,10 @@ class fra_device():
         self.is_gain = device["is_gain"]
 
 
+def mag_phase_to_complex(Z_mag, phase):
+    return Z_mag * np.exp(1j * np.deg2rad(phase))
+
+
 def open_short_compensation(Z_meas, Z_open, Z_short):
     """
     compensates the measured impedance with open and short reference measurements
@@ -149,10 +153,9 @@ def bode_to_impedance(frequency, attenuation, phase, R_device=1e6):
     """
     vratio = 10**(attenuation / 20)
     Z_dut = vratio * R_device - R_device
-    R_dut = Z_dut * np.cos(np.radians(phase))
-    X_dut = Z_dut * np.sin(np.radians(phase))
+
     omega = 2. * np.pi * frequency
-    Z_dut_complex = R_dut + 1j * X_dut
+    Z_dut_complex = mag_phase_to_complex(Z_dut, phase)
 
     return omega, Z_dut_complex
 

--- a/impedancefitter/fra.py
+++ b/impedancefitter/fra.py
@@ -153,9 +153,9 @@ def wrap_phase(phase):
     wraps the phase to -90deg to 90deg
     TODO: maybe there is a python function for this
     """
-    while(phase > 90):
+    while phase > 90:
         phase -= 180
-    while(phase < -90):
+    while phase < -90:
         phase += 180
     return phase
 
@@ -219,7 +219,7 @@ def read_bode_csv(filename, devicename):
     This function was tested for a MokuGo (Liquid Instruments) and an Rohde & Schwarz oscilloscope RTB2004
     """
     try:
-        if(devicename in ["R&S", "MokuGo"]):
+        if devicename in ["R&S", "MokuGo"]:
             devicename = f"{package_directory}/devices/{devicename}"
         with open(f"{devicename}.json", "r") as dev_file:
             device = json.load(dev_file)

--- a/impedancefitter/plotting.py
+++ b/impedancefitter/plotting.py
@@ -675,11 +675,11 @@ def plot_impedance(omega, Z, title="", Z_fit=None, show=True, save=False, Z_comp
     plt.title("Impedance real part")
     plt.ylabel(r"Re Z / $\Omega$")
     plt.xlabel('Frequency / Hz')
-    plt.plot(omega / (2. * np.pi), Z.real, label=labels[0], **plotkwargs)
+    line_Z, = plt.plot(omega / (2. * np.pi), Z.real, label=labels[0], **plotkwargs)
     if Z_fit is not None:
-        plt.plot(omega_fit / (2. * np.pi), Z_fit.real, linestyle='--', label=labels[1], **plotkwargs)
+        line_Zfit, = plt.plot(omega_fit / (2. * np.pi), Z_fit.real, linestyle='--', label=labels[1], **plotkwargs)
     if Z_comp is not None:
-        plt.plot(omega_comp / (2. * np.pi), Z_comp.real, linestyle='-.', label=labels[2], **plotkwargs)
+        line_Zcomp, = plt.plot(omega_comp / (2. * np.pi), Z_comp.real, linestyle='-.', label=labels[2], **plotkwargs)
     if legend:
         plt.legend()
     # plot imaginary part of impedance
@@ -695,41 +695,41 @@ def plot_impedance(omega, Z, title="", Z_fit=None, show=True, save=False, Z_comp
         plt.yscale('log')
         if np.all(np.less_equal(Z.imag, 0)):
             plt.ylabel(r"-Im Z / $\Omega$")
-            plt.plot(omega / (2. * np.pi), -Z.imag, label=labels[0], **plotkwargs)
+            plt.plot(omega / (2. * np.pi), -Z.imag, label=labels[0], color=line_Z.get_color(), **plotkwargs)
             if Z_fit is not None:
-                plt.plot(omega_fit / (2. * np.pi), -Z_fit.imag, '--', label=labels[1], **plotkwargs)
+                plt.plot(omega_fit / (2. * np.pi), -Z_fit.imag, '--', label=labels[1], color=line_Zfit.get_color(), **plotkwargs)
             if Z_comp is not None:
-                plt.plot(omega_comp / (2. * np.pi), -Z_comp.imag, '-.', label=labels[2], **plotkwargs)
+                plt.plot(omega_comp / (2. * np.pi), -Z_comp.imag, '-.', label=labels[2], color=line_Zcomp.get_color(), **plotkwargs)
 
         elif np.all(np.greater_equal(Z.imag, 0)):
             plt.plot(omega / (2. * np.pi), Z.imag, label=labels[0], **plotkwargs)
             if Z_fit is not None:
-                plt.plot(omega_fit / (2. * np.pi), Z_fit.imag, '--', label=labels[1], **plotkwargs)
+                plt.plot(omega_fit / (2. * np.pi), Z_fit.imag, '--', label=labels[1], color=line_Zfit.get_color(), **plotkwargs)
             if Z_comp is not None:
-                plt.plot(omega_comp / (2. * np.pi), Z_comp.imag, '-.', label=labels[2], **plotkwargs)
+                plt.plot(omega_comp / (2. * np.pi), Z_comp.imag, '-.', label=labels[2], color=line_Zcomp.get_color(), **plotkwargs)
 
         elif np.where(Z.imag < 0)[0].size > np.where(Z.imag > 0)[0].size:
             plt.ylabel(r"-Im Z / $\Omega$")
-            plt.plot(omega / (2. * np.pi), -Z.imag, label=labels[0], **plotkwargs)
+            plt.plot(omega / (2. * np.pi), -Z.imag, label=labels[0], color=line_Z.get_color(), **plotkwargs)
             if Z_fit is not None:
-                plt.plot(omega_fit / (2. * np.pi), -Z_fit.imag, '--', label=labels[1], **plotkwargs)
+                plt.plot(omega_fit / (2. * np.pi), -Z_fit.imag, '--', label=labels[1], color=line_Zfit.get_color(), **plotkwargs)
             if Z_comp is not None:
-                plt.plot(omega_comp / (2. * np.pi), -Z_comp.imag, '-.', label=labels[2], **plotkwargs)
+                plt.plot(omega_comp / (2. * np.pi), -Z_comp.imag, '-.', label=labels[2], color=line_Zcomp.get_color(), **plotkwargs)
 
         else:
-            plt.plot(omega / (2. * np.pi), Z.imag, label=labels[0], **plotkwargs)
+            plt.plot(omega / (2. * np.pi), Z.imag, label=labels[0], color=line_Z.get_color(), **plotkwargs)
             if Z_fit is not None:
-                plt.plot(omega_fit / (2. * np.pi), Z_fit.imag, '--', label=labels[1], **plotkwargs)
+                plt.plot(omega_fit / (2. * np.pi), Z_fit.imag, '--', label=labels[1], color=line_Zfit.get_color(), **plotkwargs)
             if Z_comp is not None:
-                plt.plot(omega_comp / (2. * np.pi), Z_comp.imag, '-.', label=labels[2], **plotkwargs)
+                plt.plot(omega_comp / (2. * np.pi), Z_comp.imag, '-.', label=labels[2], color=line_Zcomp.get_color(), **plotkwargs)
 
     else:
         plt.plot(omega / (2. * np.pi), Z.imag, label=labels[0], **plotkwargs)
 
         if Z_fit is not None:
-            plt.plot(omega_fit / (2. * np.pi), Z_fit.imag, '--', label=labels[1], **plotkwargs)
+            plt.plot(omega_fit / (2. * np.pi), Z_fit.imag, '--', label=labels[1], color=line_Zfit.get_color(), **plotkwargs)
         if Z_comp is not None:
-            plt.plot(omega_comp / (2. * np.pi), Z_comp.imag, '-.', label=labels[2], **plotkwargs)
+            plt.plot(omega_comp / (2. * np.pi), Z_comp.imag, '-.', label=labels[2], color=line_Zcomp.get_color(), **plotkwargs)
     if legend:
         plt.legend()
     # plot real vs negative imaginary part
@@ -764,9 +764,9 @@ def plot_impedance(omega, Z, title="", Z_fit=None, show=True, save=False, Z_comp
         plt.xlim(left=0.8 * Zmin, right=1.2 * Zmax)
         plt.ylim(bottom=0.8 * Zmin, top=1.2 * Zmax)
     if Z_fit is not None:
-        plt.plot(Z_fit.real, -Z_fit.imag, '^', label=labels[1], **plotkwargs)
+        plt.plot(Z_fit.real, -Z_fit.imag, '^', label=labels[1], color=line_Zfit.get_color(), **plotkwargs)
     if Z_comp is not None:
-        plt.plot(Z_comp.real, -Z_comp.imag, 'v', label=labels[2], **plotkwargs)
+        plt.plot(Z_comp.real, -Z_comp.imag, 'v', label=labels[2], color=line_Zcomp.get_color(), **plotkwargs)
     plt.plot(Z.real, -Z.imag, 'o', label=labels[0], **plotkwargs)
     if legend:
         plt.legend()

--- a/impedancefitter/readin.py
+++ b/impedancefitter/readin.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def readin_Data_from_collection(filepath, fileformat, delimiter=None,
-                                minimumFrequency=None, maximumFrequency=None):
+                                minimumFrequency=None, maximumFrequency=None, header=0):
     """read in data collection from Excel or CSV file.
 
     The file is structured like:
@@ -63,7 +63,7 @@ def readin_Data_from_collection(filepath, fileformat, delimiter=None,
         except XLRDError:
             EIS = pd.read_excel(filepath, engine="openpyxl")
     elif fileformat == 'CSV':
-        EIS = pd.read_csv(filepath, delimiter=delimiter)
+        EIS = pd.read_csv(filepath, delimiter=delimiter, header=header)
     else:
         raise NotImplementedError("File type not known")
 


### PR DESCRIPTION
I added a skiprows_csv=0 to the keywords to read in csv files that might have a header. Add the keyword while initializing the Fitter with the desired header length.

I also fixed a docstring in fra.py so the conversion will be explained in better detail. Also, I changed some formatting in fra.py 